### PR TITLE
remove condition to deploy to production pypi

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -46,7 +46,3 @@ jobs:
 
       - uses: pypa/gh-action-pypi-publish@release/v1
         if: github.event_name == 'release' && github.event.action == 'published'
-        with:
-          # Remember to tell (test-)pypi about this repo before publishing
-          # Remove this line to publish to PyPI
-          repository-url: https://test.pypi.org/legacy/


### PR DESCRIPTION
Remove the condition pushing the deployment of the package to test.pypi.org so that we can get it sent to production pypi.org