### PR TITLE
Copy (and deepcopy) returns ordinary dict or list respectively.

### DIFF
--- a/src/redis_json_dict/__init__.py
+++ b/src/redis_json_dict/__init__.py
@@ -10,4 +10,8 @@ from ._version import version as __version__
 
 __all__ = ["__version__"]
 
-from redis_json_dict.redis_json_dict import RedisJSONDict  # noqa: F401
+from redis_json_dict.redis_json_dict import (  # noqa: F401
+    ObservableMapping,
+    ObservableSequence,
+    RedisJSONDict,
+)

--- a/src/redis_json_dict/redis_json_dict.py
+++ b/src/redis_json_dict/redis_json_dict.py
@@ -160,6 +160,7 @@ class ObservableSequence(collections.abc.MutableSequence):
     def __deepcopy__(self, memo):
         return copy.deepcopy(self._sequence, memo)
 
+
 def observe(value, on_changed):
     "If value is a collection, return a recursively observable copy."
     if isinstance(value, collections.abc.Mapping):

--- a/src/redis_json_dict/redis_json_dict.py
+++ b/src/redis_json_dict/redis_json_dict.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import collections.abc
+import copy
 
 import orjson
 
@@ -76,6 +77,12 @@ class RedisJSONDict(collections.abc.MutableMapping):
             pipe.set(f"{self._prefix}{key}", json)
         pipe.execute()
 
+    def __copy__(self):
+        return dict(self)
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(dict(self), memo)
+
 
 class ObservableMapping(collections.abc.MutableMapping):
     def __init__(self, mapping, on_changed):
@@ -104,6 +111,12 @@ class ObservableMapping(collections.abc.MutableMapping):
 
     def __eq__(self, other):
         return self._mapping == other
+
+    def __copy__(self):
+        return copy.copy(self._mapping)
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(self._mapping, memo)
 
 
 class ObservableSequence(collections.abc.MutableSequence):
@@ -141,6 +154,11 @@ class ObservableSequence(collections.abc.MutableSequence):
     def __eq__(self, other):
         return self._sequence == other
 
+    def __copy__(self):
+        return copy.copy(self._sequence)
+
+    def __deepcopy__(self, memo):
+        return copy.deepcopy(self._sequence, memo)
 
 def observe(value, on_changed):
     "If value is a collection, return a recursively observable copy."

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import copy
+
 import pytest
+
+from redis_json_dict import ObservableMapping, ObservableSequence
 
 # ruff: noqa: ARG001
 
@@ -117,3 +121,13 @@ def test_nested_mutation(redis_server, d):
     d["x"]["y"]["z"]["k"][0]["p"].append(3)
 
     assert d == {"x": {"y": {"z": {"i": [1], "j": 2, "k": [{"p": [3]}]}}}}
+
+
+def test_copy_returns_plain_object(redis_server, d):
+    d["x"] = {}
+    d["y"] = []
+    assert isinstance(d["x"], ObservableMapping)
+    assert isinstance(d["y"], ObservableSequence)
+    c = copy.deepcopy(d)
+    assert isinstance(c["x"], dict)
+    assert isinstance(c["y"], list)


### PR DESCRIPTION
This is wanted for the pragmatic reason of needing an object that common serializers can natively serialize. A `copy` normally returns the same time of object, but in this case it's not clear what a copy would even do---you cannot have two independent copies of something whose state is externalized.

So we use copy to mean, "Make a copy with the observability stripped out."