### PR TITLE
TST: add end-to-end tests with `RE`/`db`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,8 @@ jobs:
           allow-prereleases: true
 
       - name: Install redis-server
-        run: sudo apt install redis-server
+        run: |
+          sudo apt-get update && sudo apt-get install -y redis-server
 
       - name: Install package
         run: python -m pip install .[test]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.12"]
+        python-version: ["3.10", "3.11", "3.12"]
         runs-on: [ubuntu-latest] # TODO incorporate redis-server installation for macos-latest, windows-latest
 
     steps:
@@ -62,7 +62,7 @@ jobs:
       - name: Test package
         run: >-
           python -m pytest -ra --cov --cov-report=xml --cov-report=term
-          --durations=20
+          --durations=20 -vv -s
 
       - name: Upload coverage report
         uses: codecov/codecov-action@v4.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -157,8 +157,11 @@ Thumbs.db
 *~
 *.swp
 
-#VSCode
+# VSCode
 .vscode/
 
-#pycharm
+# pycharm
 .idea/
+
+# Redis dump
+dump.rdb

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,8 +37,8 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
-  "bluesky",
-  "databroker",
+  "bluesky>=1.10.0",
+  "databroker[complete]>=2.0.0b36",
   "ophyd",
   "pytest >=6",
   "pytest-cov >=3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,11 +37,15 @@ dependencies = [
 
 [project.optional-dependencies]
 test = [
+  "bluesky",
+  "databroker",
+  "ophyd",
   "pytest >=6",
   "pytest-cov >=3",
 ]
 dev = [
   "pre-commit",
+  "pylint",
   "pytest >=6",
   "pytest-cov >=3",
 ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,7 +51,8 @@ def d():
 @pytest.fixture()
 def db():
     """Return a data broker"""
-    db = Broker.named("temp")
+    with pytest.deprecated_call():
+        db = Broker.named("temp")
     with contextlib.suppress(Exception):
         databroker.assets.utils.install_sentinels(db.reg.config, version=1)
     return db

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import subprocess
 import time as ttime
 import uuid
 
+import databroker
 import pytest
 import redis
+from bluesky import RunEngine
+from databroker import Broker
 
 from redis_json_dict import RedisJSONDict
 
@@ -42,3 +46,19 @@ def d():
     keys = list(redis_client.scan_iter(match=f"{prefix}*"))
     if keys:
         redis_client.delete(*keys)
+
+
+@pytest.fixture()
+def db():
+    """Return a data broker"""
+    db = Broker.named("temp")
+    with contextlib.suppress(Exception):
+        databroker.assets.utils.install_sentinels(db.reg.config, version=1)
+    return db
+
+
+@pytest.fixture()
+def RE():
+    loop = asyncio.new_event_loop()
+    loop.set_debug(True)
+    return RunEngine({}, loop=loop)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -146,7 +146,7 @@ def test_with_runengine_and_databroker(redis_server, d, RE, db):
 
     RE.subscribe(db.insert)
 
-    with pytest.deprecated_call(), pytest.raises(TypeError):
+    with pytest.raises(TypeError):
         RE(
             bp.count([det], md={"metadata from plan": "awesome run"}),
             md={"metadata from RE": "just a count"},
@@ -168,11 +168,10 @@ def test_with_runengine_and_databroker_deepdoc(redis_server, d, RE, db):
 
     RE.subscribe(insert)
 
-    with pytest.deprecated_call():
-        (uid,) = RE(
-            bp.count([det], md={"metadata from plan": "awesome run"}),
-            md={"metadata from RE": "just a count"},
-        )
+    (uid,) = RE(
+        bp.count([det], md={"metadata from plan": "awesome run"}),
+        md={"metadata from RE": "just a count"},
+    )
 
     hdr = db[uid]
     pprint(hdr.start)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+from pprint import pprint
 
 import bluesky.plans as bp
 import pytest
@@ -174,5 +175,6 @@ def test_with_runengine_and_databroker_deepdoc(redis_server, d, RE, db):
         )
 
     hdr = db[uid]
+    pprint(hdr.start)
     assert hdr.start["proposal"] == d["proposal"]
     assert hdr.start["proposal"] is not d["proposal"]


### PR DESCRIPTION
A follow-up PR to #6 to complement the test suite with the integration tests using RunEngine and databroker instances.

I've also noticed some linter issues/suggestions when running it locally (the `pylint` checks are currently disabled in the CI config):

```pylint
❯ pylint redis_json_dict
************* Module redis_json_dict
src/redis_json_dict/__init__.py:13:0: C0411: first party import "from redis_json_dict.redis_json_dict import ObservableMapping, ObservableSequence, RedisJSONDict" should be placed before "from ._version import version as __version__" (wrong-import-order)
************* Module src.redis_json_dict._version
src/redis_json_dict/_version.py:1:0: C0114: Missing module docstring (missing-module-docstring)
src/redis_json_dict/_version.py:6:4: C0103: Class name "VERSION_TUPLE" doesn't conform to PascalCase naming style (invalid-name)
src/redis_json_dict/_version.py:8:4: C0103: Class name "VERSION_TUPLE" doesn't conform to PascalCase naming style (invalid-name)
src/redis_json_dict/_version.py:15:14: C0103: Constant name "version" doesn't conform to UPPER_CASE naming style (invalid-name)
************* Module src.redis_json_dict.redis_json_dict
src/redis_json_dict/redis_json_dict.py:1:0: C0114: Missing module docstring (missing-module-docstring)
src/redis_json_dict/redis_json_dict.py:46:16: E1101: Module 'orjson' has no 'loads' member (no-member)
src/redis_json_dict/redis_json_dict.py:59:15: E1101: Module 'orjson' has no 'dumps' member (no-member)
src/redis_json_dict/redis_json_dict.py:72:4: W0221: Number of parameters was 1 in 'MutableMapping.update' and is now 2 in overriding 'RedisJSONDict.update' method (arguments-differ)
src/redis_json_dict/redis_json_dict.py:72:4: W0221: Variadics removed in overriding 'RedisJSONDict.update' method (arguments-differ)
src/redis_json_dict/redis_json_dict.py:76:19: E1101: Module 'orjson' has no 'dumps' member (no-member)
src/redis_json_dict/redis_json_dict.py:87:0: C0115: Missing class docstring (missing-class-docstring)
src/redis_json_dict/redis_json_dict.py:122:0: C0115: Missing class docstring (missing-class-docstring)
src/redis_json_dict/redis_json_dict.py:152:15: E1120: No value for argument 'on_changed' in constructor call (no-value-for-parameter)
src/redis_json_dict/redis_json_dict.py:183:15: W0212: Access to a protected member _mapping of a client class (protected-access)
src/redis_json_dict/redis_json_dict.py:185:15: W0212: Access to a protected member _sequence of a client class (protected-access)

-----------------------------------
Your code has been rated at 7.42/10
```