### PR TITLE
MNT: decode and then slice the prefix off

### DIFF
--- a/src/redis_json_dict/redis_json_dict.py
+++ b/src/redis_json_dict/redis_json_dict.py
@@ -29,7 +29,7 @@ class RedisJSONDict(collections.abc.MutableMapping):
     def __iter__(self):
         prefix_len = len(self._prefix)
         yield from (
-            key[prefix_len:].decode()  # slice off prefix and decode to str
+            key.decode()[prefix_len:]  # decode to str and slice off prefix
             # SCAN for all keys matching the prefix.
             # Note that, unlike KEYS, this is incremental/non-blocking.
             for key in self._redis_client.scan_iter(match=f"{self._prefix}*")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def d():
     )  # use a different port than usual because are clearing it!
     if os.environ.get("CLEAR_REDIS", "false") == "true":
         redis_client.flushall()
-    prefix = uuid.uuid4().hex
+    prefix = uuid.uuid4().hex + '\N{Snowman}'
     yield RedisJSONDict(redis_client, prefix=prefix)
     # Clean up.
     keys = list(redis_client.scan_iter(match=f"{prefix}*"))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,7 +17,7 @@ def d():
     )  # use a different port than usual because are clearing it!
     if os.environ.get("CLEAR_REDIS", "false") == "true":
         redis_client.flushall()
-    prefix = uuid.uuid4().hex + '\N{Snowman}'
+    prefix = uuid.uuid4().hex + "\N{Snowman}"
     yield RedisJSONDict(redis_client, prefix=prefix)
     # Clean up.
     keys = list(redis_client.scan_iter(match=f"{prefix}*"))


### PR DESCRIPTION
The length of a string as a string (e.g. in number of unicode codepoints) only matches the length in bytes as utf-8 for the first page (e.g. ascii).

```python
In [3]: '\N{Snowman}'
Out[3]: '☃'

In [5]: '\N{Snowman}'.encode()
Out[5]: b'\xe2\x98\x83'

In [6]: prefix = '\N{Snowman}'

In [7]: a = prefix + '_bob'

In [8]: a
Out[8]: '☃_bob'

In [9]: a.encode()[len(prefix):].decode()
---------------------------------------------------------------------------
UnicodeDecodeError                        Traceback (most recent call last)
Cell In[9], line 1
----> 1 a.encode()[len(prefix):].decode()

UnicodeDecodeError: 'utf-8' codec can't decode byte 0x98 in position 0: invalid start byte

In [10]: len(prefix)
Out[10]: 1

In [11]: len(prefix.encode())
Out[11]: 3
```